### PR TITLE
Update core.py

### DIFF
--- a/mtranslate/core.py
+++ b/mtranslate/core.py
@@ -59,7 +59,7 @@ def translate(to_translate, to_language="auto", from_language="auto"):
     """
     base_link = "http://translate.google.com/m?hl=%s&sl=%s&q=%s"
     if (sys.version_info[0] < 3):
-        to_translate = urllib.pathname2url(to_translate)
+        to_translate = urllib.quote_plus(to_translate)
         link = base_link % (to_language, from_language, to_translate)
         request = urllib2.Request(link, headers=agent)
         page = urllib2.urlopen(request).read()


### PR DESCRIPTION
urllib.pathname2url will fail when the to_translate variable contains one or more ":" (=colon). It will raise a IOError. Because this function is meant to use for urls and the colon gets handled in a specific way because of windows path's. 
Since to_translate is not really a path i propose using urllib.quote_plus.
When using urllib.quote_plus the error will not raise, it will only quote the to_translate and replacing " " (=space) with "+" (=plus) and nothing more.
