### PR TITLE
Bug fix: html.parser was not working

### DIFF
--- a/mtranslate/core.py
+++ b/mtranslate/core.py
@@ -33,7 +33,7 @@ if (sys.version_info[0] < 3):
     import urllib
     import HTMLParser
 else:
-    import html.parser
+    import html
     import urllib.request
     import urllib.parse
 
@@ -53,7 +53,7 @@ def unescape(text):
     if (sys.version_info[0] < 3):
         parser = HTMLParser.HTMLParser()
     else:
-        parser = html.parser.HTMLParser()
+        parser = html
     return (parser.unescape(text))
 
 


### PR DESCRIPTION
html.parser was not working.

python version = 3.9.1

output =
Traceback (most recent call last):
  File "/home/d.py", line 3, in <module>
    ret = mtranslate.translate("hello","tr","en")
  File "/home/mtranslate/core.py", line 87, in translate
    result = unescape(re_result[0])
  File "/home/mtranslate/core.py", line 57, in unescape
    return (parser.unescape(text))
AttributeError: 'HTMLParser' object has no attribute 'unescape'